### PR TITLE
Feature/ntp 2099

### DIFF
--- a/vp-wsdl-utils/pom.xml
+++ b/vp-wsdl-utils/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.10.8</version>
+      <version>2.13.2.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Lyft jackson-databind till icke sårbar version. Används för json-konfiguration på ett fåtal ställen.